### PR TITLE
Fix null value in DigitalOcean create record

### DIFF
--- a/libcloud/dns/drivers/digitalocean.py
+++ b/libcloud/dns/drivers/digitalocean.py
@@ -171,15 +171,15 @@ class DigitalOceanDNSDriver(DigitalOcean_v2_BaseDriver, DNSDriver):
             try:
                 params['priority'] = extra['priority']
             except KeyError:
-                params['priority'] = 'null'
+                params['priority'] = None
             try:
                 params['port'] = extra['port']
             except KeyError:
-                params['port'] = 'null'
+                params['port'] = None
             try:
                 params['weight'] = extra['weight']
             except KeyError:
-                params['weight'] = 'null'
+                params['weight'] = None
 
             if 'ttl' in extra:
                 params['ttl'] = extra['ttl']


### PR DESCRIPTION
This fixes "field could not be unmarshalled" error when trying to send
'null' as a boolean value. It needs to be int or bool, not a string.

See: https://developers.digitalocean.com/documentation/v2/#create-a-new-domain-record

Ref: https://github.com/niteoweb/easyblognetworks/issues/2132